### PR TITLE
Fix median for negative values of which

### DIFF
--- a/i0/std.i
+++ b/i0/std.i
@@ -1695,7 +1695,7 @@ func median(x, which)
   if (is_void(which)) which= 1;
   list= sort(x, which);
   dims= dimsof(x);
-  if (which<1) which= dims(1)-which;
+  if (which<1) which= dims(1)+which;
   n= dims(1+which);
   odd= n%2;
   n/= 2;         /* index with half above, half below... */


### PR DESCRIPTION
- Before the fix:
> median([[1,2,3],[4,5,6]], -1)
ERROR (median) index overreach beyond array bounds
    LINE: 1699 FILE: /Users/michel/local/libexec/yorick/i0/std.i
    To enter debug mode, type now (then dbexit to get out)

- After the fix:
> median([[1,2,3],[4,5,6]], -1)
[2,5]
